### PR TITLE
Don't attempt to pass PFX files through the tokens filter.

### DIFF
--- a/jpos-app.gradle
+++ b/jpos-app.gradle
@@ -23,6 +23,7 @@ def jposCopySpec = copySpec {
         exclude 'cfg/*.lmk'
         exclude 'cfg/*.jks'
         exclude 'cfg/*.ks'
+        exclude 'cfg/*.pfx'
         exclude 'cfg/*.ser'
         exclude 'cfg/authorized_keys'
         exclude '**/*.jpg'
@@ -40,6 +41,7 @@ def jposCopySpec = copySpec {
     from(file("src/dist")) {
         include 'cfg/*.lmk'
         include 'cfg/*.ks'
+        include 'cfg/*.pfx'
         include 'cfg/*.jks'
         include 'cfg/*.ser'
         include 'cfg/authorized_keys'


### PR DESCRIPTION
Like KS, JKS and LMK files (among others), PFX files should not be processed using the `ReplaceTokens` filter.