### PR TITLE
Use jPOS Gradle plugin 0.0.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'eclipse'
-    id 'org.jpos.jposapp' version '0.0.17'
+    id 'org.jpos.jposapp' version '0.0.19'
 }
 
 group = 'org.jpos.template'


### PR DESCRIPTION
Updates the jPOS Gradle plugin to 0.0.19.

Validation: ./gradlew help --no-daemon.